### PR TITLE
Fixing to support Android

### DIFF
--- a/Aeon HEMv2.groovy
+++ b/Aeon HEMv2.groovy
@@ -125,7 +125,7 @@ metadata {
 		valueTile("powerDisp", "device.powerDisp") {
 			state (
 				"default", 
-				label:'${currentValue}', 
+				label:'${currentValue} Watts', 
             	foregroundColors:[
             		[value: 1, color: "#000000"],
             		[value: 10000, color: "#ffffff"]
@@ -155,7 +155,7 @@ metadata {
         valueTile("powerOne", "device.powerOne") {
         	state(
         		"default", 
-        		label:'${currentValue}', 
+        		label:'${currentValue} Watts', 
             	foregroundColors:[
             		[value: 1, color: "#000000"],
             		[value: 10000, color: "#ffffff"]
@@ -185,7 +185,7 @@ metadata {
         valueTile("powerTwo", "device.powerTwo") {
         	state(
         		"default", 
-        		label:'${currentValue}', 
+        		label:'${currentValue} Watts', 
             	foregroundColors:[
             		[value: 1, color: "#000000"],
             		[value: 10000, color: "#ffffff"]
@@ -240,7 +240,7 @@ metadata {
         valueTile("voltsDisp", "device.voltsDisp") {
         	state(
         		"default", 
-        		label: '${currentValue}', 
+        		label: '${currentValue} Volts', 
         		backgroundColors:[
             		[value: "115.6", 	color: "#bc2323"],
                 	[value: "117.8", 	color: "#D04E00"],
@@ -253,7 +253,7 @@ metadata {
         valueTile("voltsOne", "device.voltsOne") {
         	state(
         		"default", 
-        		label:'${currentValue}',
+        		label:'${currentValue} Volts',
        			backgroundColors:[
        				[value: "0", color: "#ffffff"],
             		[value: "115.6", 	color: "#bc2323"],
@@ -267,7 +267,7 @@ metadata {
         valueTile("voltsTwo", "device.voltsTwo") {
         	state(
         		"default", 
-        		label:'${currentValue}',
+        		label:'${currentValue} Volts',
     			backgroundColors:[
     				[value: "0", color: "#ffffff"],
             		[value: "115.6", 	color: "#bc2323"],
@@ -283,7 +283,7 @@ metadata {
         valueTile("ampsDisp", "device.ampsDisp") {
         	state (
         		"default", 
-        		label: '${currentValue}' , 
+        		label: '${currentValue} Amps' , 
         		foregroundColor: "#000000", 
     			color: "#000000", 
     			backgroundColors:[
@@ -300,7 +300,7 @@ metadata {
         valueTile("ampsOne", "device.ampsOne") {
         	state(
         		"default",
-        		label:'${currentValue}',
+        		label:'${currentValue} Amps',
         		foregroundColor: "#000000", 
     			color: "#000000", 
     			backgroundColors:[
@@ -317,7 +317,7 @@ metadata {
         valueTile("ampsTwo", "device.ampsTwo") {
         	state(
         		"default", 
-        		label:'${currentValue}',
+        		label:'${currentValue} Amps',
         		foregroundColor: "#000000", 
     			color: "#000000", 
     			backgroundColors:[

--- a/Aeon HEMv2.groovy
+++ b/Aeon HEMv2.groovy
@@ -132,22 +132,22 @@ metadata {
             	], 
             	foregroundColor: "#000000",
                 backgroundColors:[
-					[value: "0 Watts", 		color: "#153591"],
-					[value: "3000 Watts", 	color: "#1e9cbb"],
-					[value: "6000 Watts", 	color: "#90d2a7"],
-					[value: "9000 Watts", 	color: "#44b621"],
-					[value: "12000 Watts", 	color: "#f1d801"],
-					[value: "15000 Watts", 	color: "#d04e00"], 
-					[value: "18000 Watts", 	color: "#bc2323"]
+					[value: "0", 		color: "#153591"],
+					[value: "3000", 	color: "#1e9cbb"],
+					[value: "6000", 	color: "#90d2a7"],
+					[value: "9000", 	color: "#44b621"],
+					[value: "12000", 	color: "#f1d801"],
+					[value: "15000", 	color: "#d04e00"], 
+					[value: "18000", 	color: "#bc2323"]
 					
 				/* For low-wattage homes, use these values
-					[value: "0 Watts", color: "#153591"],
-					[value: "500 Watts", color: "#1e9cbb"],
-					[value: "1000 Watts", color: "#90d2a7"],
-					[value: "1500 Watts", color: "#44b621"],
-					[value: "2000 Watts", color: "#f1d801"],
-					[value: "2500 Watts", color: "#d04e00"],
-					[value: "3000 Watts", color: "#bc2323"]
+					[value: "0", color: "#153591"],
+					[value: "500", color: "#1e9cbb"],
+					[value: "1000", color: "#90d2a7"],
+					[value: "1500", color: "#44b621"],
+					[value: "2000", color: "#f1d801"],
+					[value: "2500", color: "#d04e00"],
+					[value: "3000", color: "#bc2323"]
 				*/
 				]
 			)
@@ -162,22 +162,22 @@ metadata {
             	], 
             	foregroundColor: "#000000",
                 backgroundColors:[
-					[value: "0 Watts", 		color: "#153591"],
-					[value: "3000 Watts", 	color: "#1e9cbb"],
-					[value: "6000 Watts", 	color: "#90d2a7"],
-					[value: "9000 Watts", 	color: "#44b621"],
-					[value: "12000 Watts", 	color: "#f1d801"],
-					[value: "15000 Watts", 	color: "#d04e00"], 
-					[value: "18000 Watts", 	color: "#bc2323"]
+					[value: "0", 		color: "#153591"],
+					[value: "3000", 	color: "#1e9cbb"],
+					[value: "6000", 	color: "#90d2a7"],
+					[value: "9000", 	color: "#44b621"],
+					[value: "12000", 	color: "#f1d801"],
+					[value: "15000", 	color: "#d04e00"], 
+					[value: "18000", 	color: "#bc2323"]
 					
 				/* For low-wattage homes, use these values
-					[value: "0 Watts", color: "#153591"],
-					[value: "500 Watts", color: "#1e9cbb"],
-					[value: "1000 Watts", color: "#90d2a7"],
-					[value: "1500 Watts", color: "#44b621"],
-					[value: "2000 Watts", color: "#f1d801"],
-					[value: "2500 Watts", color: "#d04e00"],
-					[value: "3000 Watts", color: "#bc2323"]
+					[value: "0", color: "#153591"],
+					[value: "500", color: "#1e9cbb"],
+					[value: "1000", color: "#90d2a7"],
+					[value: "1500", color: "#44b621"],
+					[value: "2000", color: "#f1d801"],
+					[value: "2500", color: "#d04e00"],
+					[value: "3000", color: "#bc2323"]
 				*/
 				]
 			)
@@ -192,22 +192,22 @@ metadata {
             	], 
             	foregroundColor: "#000000",
                 backgroundColors:[
-					[value: "0 Watts", 		color: "#153591"],
-					[value: "3000 Watts", 	color: "#1e9cbb"],
-					[value: "6000 Watts", 	color: "#90d2a7"],
-					[value: "9000 Watts", 	color: "#44b621"],
-					[value: "12000 Watts", 	color: "#f1d801"],
-					[value: "15000 Watts", 	color: "#d04e00"], 
-					[value: "18000 Watts", 	color: "#bc2323"]
+					[value: "0", 		color: "#153591"],
+					[value: "3000", 	color: "#1e9cbb"],
+					[value: "6000", 	color: "#90d2a7"],
+					[value: "9000", 	color: "#44b621"],
+					[value: "12000", 	color: "#f1d801"],
+					[value: "15000", 	color: "#d04e00"], 
+					[value: "18000", 	color: "#bc2323"]
 					
 				/* For low-wattage homes, use these values
-					[value: "0 Watts", color: "#153591"],
-					[value: "500 Watts", color: "#1e9cbb"],
-					[value: "1000 Watts", color: "#90d2a7"],
-					[value: "1500 Watts", color: "#44b621"],
-					[value: "2000 Watts", color: "#f1d801"],
-					[value: "2500 Watts", color: "#d04e00"],
-					[value: "3000 Watts", color: "#bc2323"]
+					[value: "0", color: "#153591"],
+					[value: "500", color: "#1e9cbb"],
+					[value: "1000", color: "#90d2a7"],
+					[value: "1500", color: "#44b621"],
+					[value: "2000", color: "#f1d801"],
+					[value: "2500", color: "#d04e00"],
+					[value: "3000", color: "#bc2323"]
 				*/
 				]
 			)
@@ -242,11 +242,11 @@ metadata {
         		"default", 
         		label: '${currentValue}', 
         		backgroundColors:[
-            		[value: "115.6 Volts", 	color: "#bc2323"],
-                	[value: "117.8 Volts", 	color: "#D04E00"],
-                	[value: "120.0 Volts", 	color: "#44B621"],
-                	[value: "122.2 Volts", 	color: "#D04E00"],
-                	[value: "124.4 Volts", 	color: "#bc2323"]
+            		[value: "115.6", 	color: "#bc2323"],
+                	[value: "117.8", 	color: "#D04E00"],
+                	[value: "120.0", 	color: "#44B621"],
+                	[value: "122.2", 	color: "#D04E00"],
+                	[value: "124.4", 	color: "#bc2323"]
             	]
             )
         }
@@ -255,12 +255,12 @@ metadata {
         		"default", 
         		label:'${currentValue}',
        			backgroundColors:[
-       				[value: "L1", color: "#ffffff"],
-            		[value: "115.6 Volts", 	color: "#bc2323"],
-                	[value: "117.8 Volts", 	color: "#D04E00"],
-                	[value: "120.0 Volts", 	color: "#44B621"],
-                	[value: "122.2 Volts", 	color: "#D04E00"],
-                	[value: "124.4 Volts", 	color: "#bc2323"]
+       				[value: "0", color: "#ffffff"],
+            		[value: "115.6", 	color: "#bc2323"],
+                	[value: "117.8", 	color: "#D04E00"],
+                	[value: "120.0", 	color: "#44B621"],
+                	[value: "122.2", 	color: "#D04E00"],
+                	[value: "124.4", 	color: "#bc2323"]
             	]
             )
         }
@@ -269,12 +269,12 @@ metadata {
         		"default", 
         		label:'${currentValue}',
     			backgroundColors:[
-    				[value: "L2", color: "#ffffff"],
-            		[value: "115.6 Volts", 	color: "#bc2323"],
-                	[value: "117.8 Volts", 	color: "#D04E00"],
-                	[value: "120.0 Volts", 	color: "#44B621"],
-                	[value: "122.2 Volts", 	color: "#D04E00"],
-                	[value: "124.4 Volts", 	color: "#bc2323"]
+    				[value: "0", color: "#ffffff"],
+            		[value: "115.6", 	color: "#bc2323"],
+                	[value: "117.8", 	color: "#D04E00"],
+                	[value: "120.0", 	color: "#44B621"],
+                	[value: "122.2", 	color: "#D04E00"],
+                	[value: "124.4", 	color: "#bc2323"]
             	]
             )
         }
@@ -287,13 +287,13 @@ metadata {
         		foregroundColor: "#000000", 
     			color: "#000000", 
     			backgroundColors:[
-					[value: "0 Amps", 	color: "#153591"],
-					[value: "25 Amps", 	color: "#1e9cbb"],
-					[value: "50 Amps", 	color: "#90d2a7"],
-					[value: "75 Amps", 	color: "#44b621"],
-					[value: "100 Amps", color: "#f1d801"],
-					[value: "125 Amps", color: "#d04e00"], 
-					[value: "150 Amps", color: "#bc2323"]
+					[value: "0", 	color: "#153591"],
+					[value: "25", 	color: "#1e9cbb"],
+					[value: "50", 	color: "#90d2a7"],
+					[value: "75", 	color: "#44b621"],
+					[value: "100", color: "#f1d801"],
+					[value: "125", color: "#d04e00"], 
+					[value: "150", color: "#bc2323"]
 				]
 			)
         }
@@ -304,13 +304,13 @@ metadata {
         		foregroundColor: "#000000", 
     			color: "#000000", 
     			backgroundColors:[
-					[value: "0 Amps", 	color: "#153591"],
-					[value: "25 Amps", 	color: "#1e9cbb"],
-					[value: "50 Amps", 	color: "#90d2a7"],
-					[value: "75 Amps", 	color: "#44b621"],
-					[value: "100 Amps", color: "#f1d801"],
-					[value: "125 Amps", color: "#d04e00"], 
-					[value: "150 Amps", color: "#bc2323"]
+					[value: "0", 	color: "#153591"],
+					[value: "25", 	color: "#1e9cbb"],
+					[value: "50", 	color: "#90d2a7"],
+					[value: "75", 	color: "#44b621"],
+					[value: "100", color: "#f1d801"],
+					[value: "125", color: "#d04e00"], 
+					[value: "150", color: "#bc2323"]
 				]
 			)
         }
@@ -321,13 +321,13 @@ metadata {
         		foregroundColor: "#000000", 
     			color: "#000000", 
     			backgroundColors:[
-					[value: "0 Amps", 	color: "#153591"],
-					[value: "25 Amps", 	color: "#1e9cbb"],
-					[value: "50 Amps", 	color: "#90d2a7"],
-					[value: "75 Amps", 	color: "#44b621"],
-					[value: "100 Amps", color: "#f1d801"],
-					[value: "125 Amps", color: "#d04e00"], 
-					[value: "150 Amps", color: "#bc2323"]
+					[value: "0", 	color: "#153591"],
+					[value: "25", 	color: "#1e9cbb"],
+					[value: "50", 	color: "#90d2a7"],
+					[value: "75", 	color: "#44b621"],
+					[value: "100", color: "#f1d801"],
+					[value: "125", color: "#d04e00"], 
+					[value: "150", color: "#bc2323"]
 				]
 			)        		
         }


### PR DESCRIPTION
Hello,

Mobile developer/manager at SmartThings here (Kyle). I had a co-worker install this and report an issue with Android. I copied your code, installed it and sourced an issue that you should make to support Android. On the value tiles you are specifying value and color ranges for the tile but the value you are using is not a valid Double. You need to remove the units from those. Example:

**Before (background colors on a value tile):**
`[value: "0 Watts",         color: "#153591"],
[value: "3000 Watts",   color: "#1e9cbb"]` 

**After:**
`[value: "0",       color: "#153591"],
[value: "3000",     color: "#1e9cbb"]` 
