### PR TITLE
Cost display event variable name correction

### DIFF
--- a/Aeon HEMv2.groovy
+++ b/Aeon HEMv2.groovy
@@ -420,7 +420,7 @@ def zwaveEvent(physicalgraph.zwave.commands.meterv1.MeterReport cmd) {
                 BigDecimal costDecimal = newValue * ( kWhCost as BigDecimal )
                 def costDisplay = String.format("%5.2f",costDecimal)
                 state.costDisp = "Cost\n\$"+costDisplay
-                if (state.display == 1) { sendEvent(name: "energyTwo", value: state.costDisp, unit: "", descriptionText: "Display Cost: \$${costDisp}", displayed: false) }
+                if (state.display == 1) { sendEvent(name: "energyTwo", value: state.costDisp, unit: "", descriptionText: "Display Cost: \$${costDisplay}", displayed: false) }
                 [name: "energy", value: newValue, unit: "kWh", descriptionText: "Total Energy: ${formattedValue} kWh"]
             }
 		} 


### PR DESCRIPTION
The event sent for scale 0 (cost) had `descriptionText: "Display Cost: \$${costDisp}"`, but is incorrect. This changes it to the correct `costDisplay`.